### PR TITLE
* Makes gomemcached imports consistent

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-hashset"
-	"github.com/dustin/gomemcached"
+	"github.com/couchbase/gomemcached"
 
 	"github.com/couchbaselabs/cbfs/config"
 )

--- a/debug.go
+++ b/debug.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	cb "github.com/couchbaselabs/go-couchbase"
-	_ "github.com/dustin/gomemcached/debug"
+	_ "github.com/couchbase/gomemcached/debug"
 	"github.com/samuel/go-metrics/metrics"
 )
 

--- a/http.go
+++ b/http.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/gomemcached"
+	"github.com/couchbase/gomemcached"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/couchbaselabs/cbfs/config"
 	"github.com/dustin/go-humanize"
-	"github.com/dustin/gomemcached"
+	"github.com/couchbase/gomemcached"
 	"github.com/dustin/httputil"
 )
 


### PR DESCRIPTION
- Avoids duplicity of MCResponse types that can cause helper functions
  like `gomemcached.IsNotFound()` to fail, and ultimately cause the garbage collection
  to not work at all when bakupKey is missing.
